### PR TITLE
Ignore top-level array definitions

### DIFF
--- a/example/output.ts
+++ b/example/output.ts
@@ -94,7 +94,6 @@ namespace OpenAPI2 {
     type: 'provider';
     body: ProviderBody;
   }
-  export interface ProductTags {}
   export interface ProductListing {
     // When true, everyone can see the product when requested. When false it will
     // not be visible to anyone except those on the provider team.
@@ -184,7 +183,6 @@ namespace OpenAPI2 {
     type: 'product';
     body: ProductBody;
   }
-  export interface PlanResizeList {}
   export interface PlanBody {
     provider_id: string;
     product_id: string;
@@ -209,7 +207,6 @@ namespace OpenAPI2 {
     type: 'plan';
     body: PlanBody;
   }
-  export interface FeatureValuesList {}
   export interface FeatureValueDetails {
     label: string;
     name: string;

--- a/src/swagger-2.ts
+++ b/src/swagger-2.ts
@@ -175,7 +175,12 @@ function parse(spec: Swagger2, options: Swagger2Options = {}): string {
   }
 
   // Begin parsing top-level entries
-  Object.entries(definitions).forEach(entry => queue.push(entry));
+  Object.entries(definitions).forEach(entry => {
+    // Ignore top-level array definitions
+    if (entry[1].type === 'object') {
+      queue.push(entry);
+    }
+  });
   queue.sort((a, b) => a[0].localeCompare(b[0]));
   while (queue.length > 0) {
     buildNextInterface();

--- a/tests/swagger-2.test.ts
+++ b/tests/swagger-2.test.ts
@@ -362,5 +362,21 @@ describe('Swagger 2 spec', () => {
 
       expect(swaggerToTS(input)).toBe(format(output, false));
     });
+
+    it('skips top-level array definitions', () => {
+      const swagger: Swagger2 = {
+        definitions: {
+          Colors: {
+            type: 'array',
+            items: { $ref: '#/definitions/Color' },
+          },
+          Color: { type: 'string' },
+        },
+      };
+
+      const ts = format('');
+
+      expect(swaggerToTS(swagger)).toBe(ts);
+    });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "removeComments": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es5"
+    "target": "es2018"
   },
   "exclude": ["example/*", "tests/**/*"]
 }


### PR DESCRIPTION
Top-level Array types can’t be TypeScript Interfaces, so they should be ignored.

While there may be some practical usecase where this causes issues, at least for our internal specs, all our top-level array specs are referenced elsewhere, and handled correctly.

If this breaks someone’s specific usecase, the solution can be modified.