### PR TITLE
changing type check to use typeof operator instead of object property

### DIFF
--- a/src/swagger-2.ts
+++ b/src/swagger-2.ts
@@ -191,7 +191,7 @@ function parse(spec: Swagger2, options: Swagger2Options = {}): string {
   Object.entries(definitions).forEach(
     (entry): void => {
       // Ignore top-level array definitions
-      if (entry[1].type === 'object') {
+      if (typeof entry[1] === 'object') {
         queue.push(entry);
       }
     }


### PR DESCRIPTION
I was having an issue where the output was not being generated.  After debugging the script I found out this type check was the problem.  There's no `type` property on the object, so it returns `undefined` which fails the check and then the object never makes it onto the generation queue.

The proper method of type checking is to use `typeof`