### PR TITLE
Fix underscores in interface names

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
   plugins: ['@typescript-eslint', 'prettier'],
   rules: {
     '@typescript-eslint/camelcase': 0, // This is perfectly acceptable
+    'prettier/prettier': 'error',
   },
   env: {
     jest: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6674,9 +6674,9 @@
       }
     },
     "typescript": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
-      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "jest": "^24.8.0",
     "ts-jest": "^24.0.2",
     "tslib": "^1.10.0",
-    "typescript": "^3.5.1"
+    "typescript": "^3.5.3"
   }
 }

--- a/tests/swagger-2.test.ts
+++ b/tests/swagger-2.test.ts
@@ -116,7 +116,7 @@ describe('Swagger 2 spec', () => {
       expect(swaggerToTS(swagger)).toBe(ts);
     });
 
-    it('handles arrays of complex items', () => {
+    it('handles arrays of references', () => {
       const swagger: Swagger2 = {
         definitions: {
           Team: {
@@ -139,6 +139,58 @@ describe('Swagger 2 spec', () => {
         teams?: Team[];
       }
       export interface Team {
+        id?: string;
+      }`);
+
+      expect(swaggerToTS(swagger)).toBe(ts);
+    });
+
+    it('handles nested objects', () => {
+      const swagger: Swagger2 = {
+        definitions: {
+          User: {
+            properties: {
+              remote_id: {
+                type: 'object',
+                properties: { id: { type: 'string' } },
+              },
+            },
+            type: 'object',
+          },
+        },
+      };
+
+      const ts = format(`
+      export interface User {
+        remote_id?: UserRemoteId;
+      }
+      export interface UserRemoteId {
+        id?: string;
+      }`);
+
+      expect(swaggerToTS(swagger)).toBe(ts);
+    });
+
+    it('handles arrays of nested objects', () => {
+      const swagger: Swagger2 = {
+        definitions: {
+          User: {
+            properties: {
+              remote_ids: {
+                type: 'array',
+                items: { type: 'object', properties: { id: { type: 'string' } } },
+              },
+            },
+            type: 'object',
+          },
+        },
+      };
+
+      const ts = format(`
+      export interface User {
+        remote_ids?: UserRemoteIds[];
+      }
+      export interface UserRemoteIds {
         id?: string;
       }`);
 


### PR DESCRIPTION
When using nested objects, it wouldn’t transform underscores properly. Given:

```yaml
properties: {
  remote_ids: {
    type: 'object', properties: { id: { type: 'string' } } },
  },
},
```
it would return the following interface:

```ts
interface UserRemote_ids {} // 🚫
```

This now returns the following, as expected:

```ts
interface UserRemoteIds {} // ✅
```