### PR TITLE
Optional wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ npx @manifoldco/swagger-to-ts schema.yaml --wrapper "declare namespace API"
 npx @manifoldco/swagger-to-ts schema.yaml --wrapper "declare module '@api'"
 ```
 
+By default, wrapper is `declare namespace OpenAPI2`. You can skip exposing types via a wrapper by adding the `--nowrapper` flag:
+
+```bash
+npx @manifoldco/swagger-to-ts schema.yaml --nowrapper
+```
+
 As mentioned before, this uses [Prettier][prettier] to clean up output, so
 extra spaces are generally OK here. Prettier also will err on cleanup if you
 specify invalid TypeScript, letting you know on generation if anything went
@@ -102,6 +108,7 @@ also use the Node API (below).
 | `--output [location]` | `-o`  |           (stdout)           | Where should the output file be saved?                     |
 | `--swagger [version]` | `-s`  |             `2`              | Which Swagger version to use. Currently only supports `2`. |
 | `--camelcase`         | `-c`  |           `false`            | Convert `snake_case` properties to `camelCase`?            |
+| `--nowrapper`         | `-nw` |           `false`            | Disables rendering a wrapper                               |
 
 ### Node
 
@@ -128,11 +135,11 @@ specs, [glob][glob] may also come in handy.
 
 #### Node Options
 
-| Name        |   Type    |           Default            | Description                                                |
-| :---------- | :-------: | :--------------------------: | :--------------------------------------------------------- |
-| `wrapper`   | `string`  | `declare namespace OpenAPI2` | How should this export the types?                          |
-| `swagger`   | `number`  |             `2`              | Which Swagger version to use. Currently only supports `2`. |
-| `camelcase` | `boolean` |           `false`            | Convert `snake_case` properties to `camelCase`             |
+| Name        |       Type        |           Default            | Description                                                                 |
+| :---------- | :---------------: | :--------------------------: | :-------------------------------------------------------------------------- |
+| `wrapper`   | `string \| false` | `declare namespace OpenAPI2` | How should this export the types? Pass false to disable rendering a wrapper |
+| `swagger`   |     `number`      |             `2`              | Which Swagger version to use. Currently only supports `2`.                  |
+| `camelcase` |     `boolean`     |           `false`            | Convert `snake_case` properties to `camelCase`                              |
 
 [glob]: https://www.npmjs.com/package/glob
 [js-yaml]: https://www.npmjs.com/package/js-yaml

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -19,6 +19,7 @@ Options
   --output, -o      specify output file
   --camelcase, -c   convert snake_case properties to camelCase (default: off)
   --swagger, -s     specify Swagger version (default: 2)
+  --nowrapper -nw   disables rendering the wrapper
 `,
   {
     flags: {
@@ -47,6 +48,10 @@ Options
       export: {
         type: 'boolean',
         alias: 'e',
+      },
+      nowrapper: {
+        type: 'boolean',
+        alias: 'nw',
       },
     },
   }
@@ -94,7 +99,7 @@ try {
   );
 }
 
-if (cli.flags.wrapper === 'false') {
+if (cli.flags.nowrapper) {
   cli.flags.wrapper = false;
 }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -94,6 +94,10 @@ try {
   );
 }
 
+if (cli.flags.wrapper === 'false') {
+  cli.flags.wrapper = false;
+}
+
 const result = swaggerToTS(spec, cli.flags);
 
 // Write to file if specifying output

--- a/src/swagger-2.ts
+++ b/src/swagger-2.ts
@@ -22,7 +22,7 @@ export interface Swagger2 {
 
 export interface Swagger2Options {
   camelcase?: boolean;
-  wrapper?: string;
+  wrapper?: string | false;
 }
 
 // Primitives only!
@@ -47,13 +47,20 @@ function sanitize(name: string): string {
 }
 
 function parse(spec: Swagger2, options: Swagger2Options = {}): string {
-  const wrapper = options.wrapper || 'declare namespace OpenAPI2';
+  const shouldUseWrapper = options.wrapper !== false;
+  const wrapper =
+    typeof options.wrapper === 'string' && options.wrapper
+      ? options.wrapper
+      : 'declare namespace OpenAPI2';
   const shouldCamelCase = options.camelcase || false;
 
   const queue: [string, Swagger2Definition][] = [];
 
   const output: string[] = [];
-  output.push(`${wrapper} {`);
+
+  if (wrapper && shouldUseWrapper) {
+    output.push(`${wrapper} {`);
+  }
 
   const { definitions } = spec;
 
@@ -197,7 +204,9 @@ function parse(spec: Swagger2, options: Swagger2Options = {}): string {
     buildNextInterface();
   }
 
-  output.push('}'); // Close namespace
+  if (wrapper && shouldUseWrapper) {
+    output.push('}'); // Close namespace
+  }
 
   return prettier.format(output.join('\n'), { parser: 'typescript', singleQuote: true });
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -13,4 +13,10 @@ describe('swaggerToTS', () => {
     const options: Options = { swagger: 1 };
     expect(() => swaggerToTS(spec, options)).toThrowError();
   });
+
+  it('do not render a namespace when passing false to wrapper', () => {
+    const spec = { definitions: {} };
+    const options: Options = { swagger: 2, wrapper: false };
+    expect(swaggerToTS(spec, options)).toBe('');
+  });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -14,7 +14,7 @@ describe('swaggerToTS', () => {
     expect(() => swaggerToTS(spec, options)).toThrowError();
   });
 
-  it('do not render a namespace when passing false to wrapper', () => {
+  it('should not render a wrapper when passing false', () => {
     const spec = { definitions: {} };
     const options: Options = { swagger: 2, wrapper: false };
     expect(swaggerToTS(spec, options)).toBe('');


### PR DESCRIPTION
I would rather that the default behavior be no wrapper, but that would be a breaking change. 
Of course, I'm open to any other way to make `wrapper` optional