### PR TITLE
fix(utils/sanitize): Take into account the at sign

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,12 @@ export function sanitize(name: string): string {
   if (name.includes('-')) {
     return sanitized;
   }
+
+  // if key contains at sign
+  if (name.includes('@')) {
+    return sanitized;
+  }
+
   return name;
 }
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -19,6 +19,7 @@ describe('sanitize', () => {
   });
   it('invalid', () => {
     expect(sanitize('0')).toBe("'0'");
+    expect(sanitize('@type')).toBe("'@type'");
     expect(sanitize('bad-key')).toBe("'bad-key'");
   });
 });


### PR DESCRIPTION
This is not a scalable solution, but it's quite common for some fields to be prefixed with `@`.