### PR TITLE
Add SchemaReference type

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,9 +5,6 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x, 13.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/cjs",
   "version": "1.7.1",
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "bin": {
     "swagger-to-ts": "bin/cli.js"

--- a/src/types/OpenAPI2.ts
+++ b/src/types/OpenAPI2.ts
@@ -20,16 +20,17 @@ export type OpenAPI2Type =
   | 'password'
   | 'string';
 
+export type OpenAPI2Reference = { $ref: string };
+
 export interface OpenAPI2SchemaObject {
-  $ref?: string;
-  additionalProperties?: boolean | OpenAPI2SchemaObject;
+  additionalProperties?: OpenAPI2SchemaObject | OpenAPI2Reference | boolean;
   allOf?: OpenAPI2SchemaObject[];
   description?: string;
   enum?: string[];
   format?: string;
-  items?: OpenAPI2SchemaObject;
-  oneOf?: OpenAPI2SchemaObject[];
-  properties?: { [index: string]: OpenAPI2SchemaObject };
+  items?: OpenAPI2SchemaObject | OpenAPI2Reference;
+  oneOf?: (OpenAPI2SchemaObject | OpenAPI2Reference)[];
+  properties?: { [index: string]: OpenAPI2SchemaObject | OpenAPI2Reference };
   required?: string[];
   title?: string;
   type?: OpenAPI2Type;


### PR DESCRIPTION
Another chore for OpenAPI v3. This doesn’t affect Swagger v2; just provides a minor type change in preparation for v3