### PR TITLE
add default default prettier config

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
       ]
     ]
   },
+  "prettier": {},
   "scripts": {
     "build": "pika build",
     "lint": "eslint --ignore-path .gitignore --ext .js,.ts src",


### PR DESCRIPTION
This is useful to avoid prettier to pick up global prettier config in case it is different from what is used in the project.