### PR TITLE
Improve array and object handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@manifoldco/swagger-to-ts",
   "description": "Generate TypeScript types from Swagger OpenAPI specs",
   "main": "dist/cjs",
-  "version": "2.0.0-alpha.5",
+  "version": "2.0.0-alpha.6",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/src/types/OpenAPI2.ts
+++ b/src/types/OpenAPI2.ts
@@ -39,6 +39,6 @@ export interface OpenAPI2SchemaObject {
   properties?: { [index: string]: OpenAPI2SchemaObject | OpenAPI2Reference };
   required?: string[];
   title?: string;
-  type?: OpenAPI2Type;
+  type?: OpenAPI2Type; // allow this to be optional to cover cases when this is missing
   [key: string]: any; // allow arbitrary x-something properties
 }

--- a/src/types/OpenAPI3.ts
+++ b/src/types/OpenAPI3.ts
@@ -36,6 +36,6 @@ export interface OpenAPI3SchemaObject {
   properties?: { [key: string]: OpenAPI3SchemaObject | OpenAPI3Reference };
   required?: string[];
   title?: string;
-  type: OpenAPI3Type;
+  type?: OpenAPI3Type; // allow this to be optional to cover cases when this is missing
   [key: string]: any; // allow arbitrary x-something properties
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,23 +66,13 @@ export function nodeType(obj: any): SchemaObjectType | undefined {
     return "oneOf";
   }
 
-  // object
-  if (
-    obj.type === "object" ||
-    !!obj.properties ||
-    !!obj.allOf ||
-    !!obj.additionalProperties
-  ) {
-    return "object";
-  }
-
   // array
-  if (obj.type === "array") {
+  if (obj.type === "array" || obj.items) {
     return "array";
   }
 
-  // other / unknown
-  return obj.type;
+  // return object by default
+  return "object";
 }
 
 /** Return OpenAPI version from definition */

--- a/tests/v2/index.test.ts
+++ b/tests/v2/index.test.ts
@@ -160,6 +160,7 @@ describe("transformation", () => {
             type: "object",
           },
           object_unknown: { type: "object" },
+          object_empty: {},
         },
       };
       expect(swaggerToTS(schema)).toBe(
@@ -172,6 +173,7 @@ describe("transformation", () => {
           };
           object_ref: { number?: number };
           object_unknown: { [key: string]: any };
+          object_empty: { [key: string]: any };
         }`)
       );
     });
@@ -192,6 +194,9 @@ describe("transformation", () => {
             },
             type: "object",
           },
+          inferred_array: {
+            items: { $ref: "#/definitions/array" },
+          },
           string: { type: "string" },
           array_ref: { items: { $ref: "#/definitions/array" }, type: "array" },
         },
@@ -206,6 +211,7 @@ describe("transformation", () => {
             numbers?: number[];
             refs?: definitions['string'][];
           };
+          inferred_array: definitions['array'][];
           string: string;
           array_ref: definitions['array'][];
         }`)

--- a/tests/v3/index.test.ts
+++ b/tests/v3/index.test.ts
@@ -140,6 +140,7 @@ describe("types", () => {
             type: "object",
           },
           object_unknown: { type: "object" },
+          object_empty: {},
         },
       },
     };
@@ -154,6 +155,7 @@ describe("types", () => {
           };
           object_ref: { number?: number };
           object_unknown: { [key: string]: any };
+          object_empty: { [key: string]: any };
         }
       }`)
     );
@@ -179,6 +181,9 @@ describe("types", () => {
             },
             type: "object",
           },
+          inferred_array: {
+            items: { $ref: "#/components/schemas/array" },
+          },
           string: { type: "string" },
           array_ref: {
             items: { $ref: "#/components/schemas/array" },
@@ -198,6 +203,7 @@ describe("types", () => {
             numbers?: number[];
             refs?: components['schemas']['string'][];
           };
+          inferred_array: components['schemas']['array'][];
           string: string;
           array_ref: components['schemas']['array'][];
         }
@@ -377,7 +383,7 @@ describe("OpenAPI3 features", () => {
                 oneOf: [
                   { type: "string" },
                   { type: "number" },
-                  { $ref: "#/components/one_of_ref" },
+                  { $ref: "#/components/schemas/one_of_ref" },
                 ],
               },
             },
@@ -389,6 +395,26 @@ describe("OpenAPI3 features", () => {
             },
             type: "object",
           },
+          one_of_inferred: {
+            oneOf: [
+              {
+                properties: {
+                  kibana: {
+                    type: "object",
+                    properties: { versions: { type: "string" } },
+                  },
+                },
+              },
+              {
+                properties: {
+                  elasticsearch: {
+                    type: "object",
+                    properties: { versions: { type: "string" } },
+                  },
+                },
+              },
+            ],
+          },
         },
       },
     };
@@ -397,8 +423,11 @@ describe("OpenAPI3 features", () => {
       format(`
     export interface components {
       schemas: {
-        one_of: { options?: string | number | components['one_of_ref'] };
+        one_of: { options?: string | number | components['schemas']['one_of_ref'] };
         one_of_ref: { boolean?: boolean };
+        one_of_inferred:
+          | { kibana?: { versions?: string } }
+          | { elasticsearch?: { versions?: string } }
       }
     }`)
     );


### PR DESCRIPTION
Many schemas omit information because the OpenAPI spec allows (such as omitting `type: object' or `type: array' and inferring from other properties). This adds _robustity_ to handle that.