### PR TITLE
Add 2.0 warning

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -29,6 +29,11 @@ Options
   }
 );
 
+console.info(chalk.bold(`✨ swagger-to-ts 2.0`));
+console.info(
+  "This library has been updated to 2.0 with improved generation. If you experience issues you can use the deprecated v1 with `npx @manifoldco/swagger-to-ts@1 …`"
+);
+
 const pathToSpec = cli.input[0];
 const timeStart = process.hrtime();
 


### PR DESCRIPTION
Adds the following warning with the `2.0` release:

<img width="708" alt="Screen Shot 2020-05-04 at 22 03 18" src="https://user-images.githubusercontent.com/1369770/81034061-1d1b9c80-8e53-11ea-9560-7e1ed8074763.png">
