### PR TITLE
Support for components.responses

### DIFF
--- a/src/types/OpenAPI3.ts
+++ b/src/types/OpenAPI3.ts
@@ -8,6 +8,7 @@ export interface OpenAPI3 {
   openapi: string;
   components: {
     schemas: { [key: string]: OpenAPI3SchemaObject | OpenAPI3Reference };
+    responses?: { [key: string]: OpenAPI3SchemaObject | OpenAPI3Reference };
   };
   [key: string]: any; // handle other properties beyond swagger-to-ts’ concern
 }

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -126,10 +126,17 @@ export default function generateTypesV3(
     return output;
   }
 
+  const schemas = `schemas: {
+    ${createKeys(propertyMapped, Object.keys(propertyMapped))}
+  }`
+
+  const responses = !schema.components.responses ? `` : `responses: {
+    ${createKeys(schema.components.responses, Object.keys(schema.components.responses))}
+  }`
+
   // note: make sure that base-level schemas are required
   return `export interface components {
-    schemas: {
-      ${createKeys(propertyMapped, Object.keys(propertyMapped))}
-    }
+    ${schemas}
+    ${responses}
   }`;
 }

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -128,11 +128,16 @@ export default function generateTypesV3(
 
   const schemas = `schemas: {
     ${createKeys(propertyMapped, Object.keys(propertyMapped))}
-  }`
+  }`;
 
-  const responses = !schema.components.responses ? `` : `responses: {
-    ${createKeys(schema.components.responses, Object.keys(schema.components.responses))}
-  }`
+  const responses = !schema.components.responses
+    ? ``
+    : `responses: {
+    ${createKeys(
+      schema.components.responses,
+      Object.keys(schema.components.responses)
+    )}
+  }`;
 
   // note: make sure that base-level schemas are required
   return `export interface components {

--- a/tests/v3/expected/petstore.ts
+++ b/tests/v3/expected/petstore.ts
@@ -42,6 +42,8 @@ export interface components {
        */
       status?: "available" | "pending" | "sold";
     };
+  };
+  responses: {
     ApiResponse: { code?: number; type?: string; message?: string };
   };
 }

--- a/tests/v3/specs/petstore.yaml
+++ b/tests/v3/specs/petstore.yaml
@@ -707,6 +707,7 @@ components:
             - sold
       xml:
         name: Pet
+  responses:
     ApiResponse:
       type: object
       properties:


### PR DESCRIPTION
I'm using Typescript on both the client and server side to strictly type my API requests / responses, and the [Swagger components section](https://swagger.io/docs/specification/components/) includes suggested usage of the `components.responses` key.

This adds the support with as little ceremony as possible (responses isn't required, property mapping is only used for schemas, no changes to schemas usage, etc.). If you'd like it to be generalized a bit more to encourage mapping more pieces of the Swagger spec, happy to do so.