### PR TITLE
Support raw schemas in addition to Swagger/OpenAPI documents

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,6 +15,8 @@ Options
   --help                display this
   --output, -o          specify output file
   --prettier-config     (optional) specify path to Prettier config file
+  --raw-schema          (optional) Read from raw schema instead of document
+  --version             (optional) Schema version (must be present for raw schemas)
 `,
   {
     flags: {
@@ -25,6 +27,12 @@ Options
       prettierConfig: {
         type: "string",
       },
+      rawSchema: {
+        type: "boolean"
+      },
+      version: {
+        type: "number"
+      }
     },
   }
 );
@@ -47,6 +55,8 @@ const timeStart = process.hrtime();
 
   const result = swaggerToTS(spec, {
     prettierConfig: cli.flags.prettierConfig,
+    rawSchema: cli.flags.rawSchema,
+    version: cli.flags.version
   });
 
   // Write to file if specifying output

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,13 @@
 import path from "path";
 import prettier from "prettier";
 import { swaggerVersion } from "./utils";
-import { OpenAPI2, OpenAPI3, SwaggerToTSOptions } from "./types";
+import {
+  OpenAPI2,
+  OpenAPI2Schemas,
+  OpenAPI3,
+  OpenAPI3Schemas,
+  SwaggerToTSOptions,
+} from "./types";
 import v2 from "./v2";
 import v3 from "./v3";
 
@@ -14,19 +20,20 @@ export const WARNING_MESSAGE = `/**
 `;
 
 export default function swaggerToTS(
-  schema: OpenAPI2 | OpenAPI3,
+  schema: OpenAPI2 | OpenAPI2Schemas | OpenAPI3 | OpenAPI3Schemas,
   options?: SwaggerToTSOptions
 ): string {
   // generate types for V2 and V3
-  const version = swaggerVersion(schema);
+  const version =
+    options?.version || swaggerVersion(schema as OpenAPI2 | OpenAPI3);
   let output = `${WARNING_MESSAGE}`;
   switch (version) {
     case 2: {
-      output = output.concat(v2(schema as OpenAPI2, options));
+      output = output.concat(v2(schema as OpenAPI2 | OpenAPI2Schemas, options));
       break;
     }
     case 3: {
-      output = output.concat(v3(schema as OpenAPI3, options));
+      output = output.concat(v3(schema as OpenAPI3 | OpenAPI3Schemas, options));
       break;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,8 @@ export default function swaggerToTS(
 ): string {
   // generate types for V2 and V3
   const version =
-    options?.version || swaggerVersion(schema as OpenAPI2 | OpenAPI3);
+    (options && options.version) ||
+    swaggerVersion(schema as OpenAPI2 | OpenAPI3);
   let output = `${WARNING_MESSAGE}`;
   switch (version) {
     case 2: {

--- a/src/types/OpenAPI2.ts
+++ b/src/types/OpenAPI2.ts
@@ -4,8 +4,12 @@
  * the parts that swagger-to-ts needs to know about.
  */
 
+export interface OpenAPI2Schemas {
+  [key: string]: OpenAPI2SchemaObject;
+}
+
 export interface OpenAPI2 {
-  definitions?: { [key: string]: OpenAPI2SchemaObject };
+  definitions?: OpenAPI2Schemas;
   swagger: string;
   [key: string]: any; // handle other properties beyond swagger-to-ts’ concern
 }

--- a/src/types/OpenAPI3.ts
+++ b/src/types/OpenAPI3.ts
@@ -4,10 +4,14 @@
  * the parts that swagger-to-ts needs to know about.
  */
 
+export interface OpenAPI3Schemas {
+  [key: string]: OpenAPI3SchemaObject | OpenAPI3Reference;
+}
+
 export interface OpenAPI3 {
   openapi: string;
   components: {
-    schemas: { [key: string]: OpenAPI3SchemaObject | OpenAPI3Reference };
+    schemas: OpenAPI3Schemas;
   };
   [key: string]: any; // handle other properties beyond swagger-to-ts’ concern
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,4 +18,8 @@ export interface SwaggerToTSOptions {
     schemaObject: OpenAPI2SchemaObject | OpenAPI3SchemaObject,
     property: Property
   ) => Property;
+  /** (optinal) Parsing input document as raw schema rather than OpenAPI document */
+  rawSchema?: boolean;
+  /** (optional) OpenAPI version. Must be present if parsing raw schema */
+  version?: number;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,8 +95,8 @@ export function swaggerVersion(definition: OpenAPI2 | OpenAPI3): 2 | 3 {
 }
 
 /** Convert $ref to TS ref */
-export function transformRef(ref: string): string {
-  const parts = ref.replace(/^#\//, "").split("/");
+export function transformRef(ref: string, root = ""): string {
+  const parts = ref.replace(/^#\//, root).split("/");
   return `${parts[0]}["${parts.slice(1).join('"]["')}"]`;
 }
 

--- a/src/v2.ts
+++ b/src/v2.ts
@@ -37,14 +37,21 @@ export default function generateTypesV2(
   input: OpenAPI2 | OpenAPI2Schemas,
   options?: SwaggerToTSOptions
 ): string {
-  const definitions = options?.rawSchema
-    ? (input as OpenAPI2Schemas)
-    : (input as OpenAPI2).definitions;
+  const rawSchema = options && options.rawSchema;
 
-  if (!definitions) {
-    throw new Error(
-      `⛔️ 'definitions' missing from schema https://swagger.io/specification/v2/#definitions-object`
-    );
+  let definitions: OpenAPI2Schemas;
+
+  if (rawSchema) {
+    definitions = input as OpenAPI2Schemas;
+  } else {
+    const document = input as OpenAPI2;
+
+    if (!document.definitions) {
+      throw new Error(
+        `⛔️ 'definitions' missing from schema https://swagger.io/specification/v2/#definitions-object`
+      );
+    }
+    definitions = document.definitions;
   }
 
   // propertyMapper
@@ -56,10 +63,7 @@ export default function generateTypesV2(
   function transform(node: OpenAPI2SchemaObject): string {
     switch (nodeType(node)) {
       case "ref": {
-        return transformRef(
-          node.$ref,
-          options?.rawSchema ? "definitions/" : ""
-        );
+        return transformRef(node.$ref, rawSchema ? "definitions/" : "");
       }
       case "string":
       case "number":


### PR DESCRIPTION
This adds support for supplying raw v3 schemas or v2 definitions as an alternative to supplying full Swagger/OpenAPI documents, using an option `--raw-schema` in combination with `--version`.

Previously, swagger-to-ts would require `components` to be present in the given document, even though it's an optional property. When dealing with large documents, it's common practice to
split it over several files, putting e.g. schemas in separate files.

This change enables producing types for such stand-alone schemas by adding an option to parse the given file as a map of schemas  rather than a document. For this to work, the version must also be passed since it's not present in raw schemas/definitions.

For example, if the full document is:

```
openapi: 3.0.2
components:
  schemas:
    Foo:
      type: object
    Bar:
      type: object
      properties:
        foo: {$ref: '#/components/schemas/Foo'}
```

Then it's now possible to parse the schemas separately by passing a file with the following contents, and `--raw-schema --version 3` as options:

```
Foo:
  type: object
Bar:
  type: object
  properties:
    foo: {$ref: '#/Foo'}
```

For V3, the output differs from the output produced for OpenAPI3 documents in that
`schemas: { ... }` is the exported interface instead of
`components: { schemas: { ... } }`.

For V2, `definitions: { ... }` is still exported.