### PR TITLE
additionalProperties interpolation, primitive enums

### DIFF
--- a/examples/stripe-openapi2.ts
+++ b/examples/stripe-openapi2.ts
@@ -678,83 +678,83 @@ export interface definitions {
       | "unapplied_from_invoice"
       | "unspent_receiver_credit";
   };
-  deleted_account: { deleted: "true"; id: string; object: "account" };
+  deleted_account: { deleted: true; id: string; object: "account" };
   deleted_alipay_account: {
-    deleted: "true";
+    deleted: true;
     id: string;
     object: "alipay_account";
   };
   deleted_apple_pay_domain: {
-    deleted: "true";
+    deleted: true;
     id: string;
     object: "apple_pay_domain";
   };
   deleted_bank_account: {
     currency?: string;
-    deleted: "true";
+    deleted: true;
     id: string;
     object: "bank_account";
   };
   deleted_bitcoin_receiver: {
-    deleted: "true";
+    deleted: true;
     id: string;
     object: "bitcoin_receiver";
   };
   deleted_card: {
     currency?: string;
-    deleted: "true";
+    deleted: true;
     id: string;
     object: "card";
   };
-  deleted_coupon: { deleted: "true"; id: string; object: "coupon" };
-  deleted_customer: { deleted: "true"; id: string; object: "customer" };
-  deleted_discount: { deleted: "true"; object: "discount" };
+  deleted_coupon: { deleted: true; id: string; object: "coupon" };
+  deleted_customer: { deleted: true; id: string; object: "customer" };
+  deleted_discount: { deleted: true; object: "discount" };
   deleted_external_account: {
     currency?: string;
-    deleted: "true";
+    deleted: true;
     id: string;
     object: "bank_account";
   };
-  deleted_invoice: { deleted: "true"; id: string; object: "invoice" };
-  deleted_invoiceitem: { deleted: "true"; id: string; object: "invoiceitem" };
+  deleted_invoice: { deleted: true; id: string; object: "invoice" };
+  deleted_invoiceitem: { deleted: true; id: string; object: "invoiceitem" };
   deleted_payment_source: {
-    deleted: "true";
+    deleted: true;
     id: string;
     object: "alipay_account";
   };
-  deleted_person: { deleted: "true"; id: string; object: "person" };
-  deleted_plan: { deleted: "true"; id: string; object: "plan" };
-  deleted_product: { deleted: "true"; id: string; object: "product" };
+  deleted_person: { deleted: true; id: string; object: "person" };
+  deleted_plan: { deleted: true; id: string; object: "plan" };
+  deleted_product: { deleted: true; id: string; object: "product" };
   "deleted_radar.value_list": {
-    deleted: "true";
+    deleted: true;
     id: string;
     object: "radar.value_list";
   };
   "deleted_radar.value_list_item": {
-    deleted: "true";
+    deleted: true;
     id: string;
     object: "radar.value_list_item";
   };
-  deleted_recipient: { deleted: "true"; id: string; object: "recipient" };
-  deleted_sku: { deleted: "true"; id: string; object: "sku" };
+  deleted_recipient: { deleted: true; id: string; object: "recipient" };
+  deleted_sku: { deleted: true; id: string; object: "sku" };
   deleted_subscription_item: {
-    deleted: "true";
+    deleted: true;
     id: string;
     object: "subscription_item";
   };
-  deleted_tax_id: { deleted: "true"; id: string; object: "tax_id" };
+  deleted_tax_id: { deleted: true; id: string; object: "tax_id" };
   "deleted_terminal.location": {
-    deleted: "true";
+    deleted: true;
     id: string;
     object: "terminal.location";
   };
   "deleted_terminal.reader": {
-    deleted: "true";
+    deleted: true;
     id: string;
     object: "terminal.reader";
   };
   deleted_webhook_endpoint: {
-    deleted: "true";
+    deleted: true;
     id: string;
     object: "webhook_endpoint";
   };

--- a/examples/stripe-openapi3.ts
+++ b/examples/stripe-openapi3.ts
@@ -737,82 +737,82 @@ export interface components {
         | "unapplied_from_invoice"
         | "unspent_receiver_credit";
     };
-    deleted_account: { deleted: "true"; id: string; object: "account" };
+    deleted_account: { deleted: true; id: string; object: "account" };
     deleted_alipay_account: {
-      deleted: "true";
+      deleted: true;
       id: string;
       object: "alipay_account";
     };
     deleted_apple_pay_domain: {
-      deleted: "true";
+      deleted: true;
       id: string;
       object: "apple_pay_domain";
     };
     deleted_bank_account: {
       currency?: string;
-      deleted: "true";
+      deleted: true;
       id: string;
       object: "bank_account";
     };
     deleted_bitcoin_receiver: {
-      deleted: "true";
+      deleted: true;
       id: string;
       object: "bitcoin_receiver";
     };
     deleted_card: {
       currency?: string;
-      deleted: "true";
+      deleted: true;
       id: string;
       object: "card";
     };
-    deleted_coupon: { deleted: "true"; id: string; object: "coupon" };
-    deleted_customer: { deleted: "true"; id: string; object: "customer" };
-    deleted_discount: { deleted: "true"; object: "discount" };
+    deleted_coupon: { deleted: true; id: string; object: "coupon" };
+    deleted_customer: { deleted: true; id: string; object: "customer" };
+    deleted_discount: { deleted: true; object: "discount" };
     deleted_external_account: Partial<
       components["schemas"]["deleted_bank_account"]
     > &
       Partial<components["schemas"]["deleted_card"]>;
-    deleted_invoice: { deleted: "true"; id: string; object: "invoice" };
-    deleted_invoiceitem: { deleted: "true"; id: string; object: "invoiceitem" };
+    deleted_invoice: { deleted: true; id: string; object: "invoice" };
+    deleted_invoiceitem: { deleted: true; id: string; object: "invoiceitem" };
     deleted_payment_source: Partial<
       components["schemas"]["deleted_alipay_account"]
     > &
       Partial<components["schemas"]["deleted_bank_account"]> &
       Partial<components["schemas"]["deleted_bitcoin_receiver"]> &
       Partial<components["schemas"]["deleted_card"]>;
-    deleted_person: { deleted: "true"; id: string; object: "person" };
-    deleted_plan: { deleted: "true"; id: string; object: "plan" };
-    deleted_product: { deleted: "true"; id: string; object: "product" };
+    deleted_person: { deleted: true; id: string; object: "person" };
+    deleted_plan: { deleted: true; id: string; object: "plan" };
+    deleted_product: { deleted: true; id: string; object: "product" };
     "deleted_radar.value_list": {
-      deleted: "true";
+      deleted: true;
       id: string;
       object: "radar.value_list";
     };
     "deleted_radar.value_list_item": {
-      deleted: "true";
+      deleted: true;
       id: string;
       object: "radar.value_list_item";
     };
-    deleted_recipient: { deleted: "true"; id: string; object: "recipient" };
-    deleted_sku: { deleted: "true"; id: string; object: "sku" };
+    deleted_recipient: { deleted: true; id: string; object: "recipient" };
+    deleted_sku: { deleted: true; id: string; object: "sku" };
     deleted_subscription_item: {
-      deleted: "true";
+      deleted: true;
       id: string;
       object: "subscription_item";
     };
-    deleted_tax_id: { deleted: "true"; id: string; object: "tax_id" };
+    deleted_tax_id: { deleted: true; id: string; object: "tax_id" };
     "deleted_terminal.location": {
-      deleted: "true";
+      deleted: true;
       id: string;
       object: "terminal.location";
     };
     "deleted_terminal.reader": {
-      deleted: "true";
+      deleted: true;
       id: string;
       object: "terminal.reader";
     };
     deleted_webhook_endpoint: {
-      deleted: "true";
+      deleted: true;
       id: string;
       object: "webhook_endpoint";
     };

--- a/src/v2.ts
+++ b/src/v2.ts
@@ -55,7 +55,7 @@ export default function generateTypesV2(
         return nodeType(node) || "any";
       }
       case "enum": {
-        return tsUnionOf((node.enum as string[]).map((item) => `'${item}'`));
+        return tsUnionOf((node.enum as string[]).map((item) => typeof item === 'number' ? item : `'${item}'`));
       }
       case "object": {
         if (

--- a/src/v2.ts
+++ b/src/v2.ts
@@ -57,7 +57,9 @@ export default function generateTypesV2(
       case "enum": {
         return tsUnionOf(
           (node.enum as string[]).map((item) =>
-            typeof item === "number" ? item : `'${item}'`
+            typeof item === "number" || typeof item === "boolean"
+              ? item
+              : `'${item}'`
           )
         );
       }

--- a/src/v2.ts
+++ b/src/v2.ts
@@ -55,7 +55,11 @@ export default function generateTypesV2(
         return nodeType(node) || "any";
       }
       case "enum": {
-        return tsUnionOf((node.enum as string[]).map((item) => typeof item === 'number' ? item : `'${item}'`));
+        return tsUnionOf(
+          (node.enum as string[]).map((item) =>
+            typeof item === "number" ? item : `'${item}'`
+          )
+        );
       }
       case "object": {
         if (

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -49,7 +49,7 @@ export default function generateTypesV3(
         return nodeType(node) || "any";
       }
       case "enum": {
-        return tsUnionOf((node.enum as string[]).map((item) => `'${item}'`));
+        return tsUnionOf((node.enum as string[]).map((item) => typeof item === 'number' ? item : `'${item}'`));
       }
       case "oneOf": {
         return tsUnionOf((node.oneOf as any[]).map(transform));

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -74,7 +74,9 @@ export default function generateTypesV3(
         // if additional properties, add to end of properties
         if (node.additionalProperties) {
           properties += `[key: string]: ${
-            nodeType(node.additionalProperties) || "any"
+            node.additionalProperties === true
+              ? 'any'
+              : transform(node.additionalProperties) || "any"
           };\n`;
         }
 

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -51,7 +51,9 @@ export default function generateTypesV3(
       case "enum": {
         return tsUnionOf(
           (node.enum as string[]).map((item) =>
-            typeof item === "number" ? item : `'${item}'`
+            typeof item === "number" || typeof item === "boolean"
+              ? item
+              : `'${item}'`
           )
         );
       }

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -75,7 +75,7 @@ export default function generateTypesV3(
         if (node.additionalProperties) {
           properties += `[key: string]: ${
             node.additionalProperties === true
-              ? 'any'
+              ? "any"
               : transform(node.additionalProperties) || "any"
           };\n`;
         }

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -49,7 +49,11 @@ export default function generateTypesV3(
         return nodeType(node) || "any";
       }
       case "enum": {
-        return tsUnionOf((node.enum as string[]).map((item) => typeof item === 'number' ? item : `'${item}'`));
+        return tsUnionOf(
+          (node.enum as string[]).map((item) =>
+            typeof item === "number" ? item : `'${item}'`
+          )
+        );
       }
       case "oneOf": {
         return tsUnionOf((node.oneOf as any[]).map(transform));

--- a/tests/v2/expected/http.ts
+++ b/tests/v2/expected/http.ts
@@ -32,7 +32,7 @@ export interface definitions {
     body: definitions["ExpandedPlanBody"];
     id: definitions["ID"];
     type: "plan";
-    version: "1";
+    version: 1;
   };
   ExpandedPlanBody: definitions["PlanBody"] & {
     /**
@@ -58,7 +58,7 @@ export interface definitions {
     plans?: definitions["ExpandedPlan"][];
     provider: definitions["Provider"];
     type: "product";
-    version: "1";
+    version: 1;
   };
   /**
    * Optional container for additional details relating to numeric features.
@@ -239,7 +239,7 @@ export interface definitions {
     body: definitions["PlanBody"];
     id: definitions["ID"];
     type: "plan";
-    version: "1";
+    version: 1;
   };
   PlanBody: {
     /**
@@ -304,7 +304,7 @@ export interface definitions {
     body: definitions["ProductBody"];
     id: definitions["ID"];
     type: "product";
-    version: "1";
+    version: 1;
   };
   ProductBody: {
     billing: {
@@ -446,7 +446,7 @@ export interface definitions {
     body: definitions["ProviderBody"];
     id: definitions["ID"];
     type: "provider";
-    version: "1";
+    version: 1;
   };
   ProviderBody: {
     documentation_url?: string;
@@ -461,7 +461,7 @@ export interface definitions {
     body: definitions["RegionBody"];
     id: definitions["ID"];
     type: "region";
-    version: "1";
+    version: 1;
   };
   RegionBody: {
     location: definitions["Location"];

--- a/tests/v2/expected/manifold.ts
+++ b/tests/v2/expected/manifold.ts
@@ -69,7 +69,7 @@ export interface definitions {
   Region: {
     id: definitions["ID"];
     type: "region";
-    version: "1";
+    version: 1;
     body: definitions["RegionBody"];
   };
   CreateRegion: { body: definitions["RegionBody"] };
@@ -94,7 +94,7 @@ export interface definitions {
   };
   Provider: {
     id: definitions["ID"];
-    version: "1";
+    version: 1;
     type: "provider";
     body: definitions["ProviderBody"];
   };
@@ -451,7 +451,7 @@ export interface definitions {
   };
   Product: {
     id: definitions["ID"];
-    version: "1";
+    version: 1;
     type: "product";
     body: definitions["ProductBody"];
   };
@@ -514,13 +514,13 @@ export interface definitions {
   };
   Plan: {
     id: definitions["ID"];
-    version: "1";
+    version: 1;
     type: "plan";
     body: definitions["PlanBody"];
   };
   ExpandedPlan: {
     id: definitions["ID"];
-    version: "1";
+    version: 1;
     type: "plan";
     body: definitions["ExpandedPlanBody"];
   };
@@ -564,7 +564,7 @@ export interface definitions {
   PriceFormula: string;
   ExpandedProduct: {
     id: definitions["ID"];
-    version: "1";
+    version: 1;
     type: "product";
     body: definitions["ProductBody"];
     plans?: definitions["ExpandedPlan"][];

--- a/tests/v2/expected/stripe.ts
+++ b/tests/v2/expected/stripe.ts
@@ -2141,7 +2141,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2155,7 +2155,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2169,7 +2169,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2187,7 +2187,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2201,7 +2201,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2219,7 +2219,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2233,7 +2233,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2247,7 +2247,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2261,7 +2261,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * String representing the object's type. Objects of the same type share the same value.
      */
@@ -2275,7 +2275,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2289,7 +2289,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2303,7 +2303,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2317,7 +2317,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2331,7 +2331,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2345,7 +2345,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2359,7 +2359,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2373,7 +2373,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2387,7 +2387,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2401,7 +2401,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2415,7 +2415,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2429,7 +2429,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2443,7 +2443,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2457,7 +2457,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2471,7 +2471,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */
@@ -2485,7 +2485,7 @@ export interface definitions {
     /**
      * Always true for a deleted object
      */
-    deleted: "true";
+    deleted: true;
     /**
      * Unique identifier for the object.
      */

--- a/tests/v3/expected/stripe.ts
+++ b/tests/v3/expected/stripe.ts
@@ -2298,7 +2298,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2312,7 +2312,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2326,7 +2326,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2344,7 +2344,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2358,7 +2358,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2376,7 +2376,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2390,7 +2390,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2404,7 +2404,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2418,7 +2418,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * String representing the object's type. Objects of the same type share the same value.
        */
@@ -2432,7 +2432,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2446,7 +2446,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2466,7 +2466,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2480,7 +2480,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2494,7 +2494,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2508,7 +2508,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2522,7 +2522,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2536,7 +2536,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2550,7 +2550,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2564,7 +2564,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2578,7 +2578,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2592,7 +2592,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2606,7 +2606,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */
@@ -2620,7 +2620,7 @@ export interface components {
       /**
        * Always true for a deleted object
        */
-      deleted: "true";
+      deleted: true;
       /**
        * Unique identifier for the object.
        */

--- a/tests/v3/expected/stripe.ts
+++ b/tests/v3/expected/stripe.ts
@@ -1744,7 +1744,7 @@ export interface components {
       /**
        * Currencies that can be accepted in the specific country (for transfers).
        */
-      supported_bank_account_currencies: { [key: string]: array };
+      supported_bank_account_currencies: { [key: string]: string[] };
       /**
        * Currencies that can be accepted in the specified country (for payments).
        */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "ESNext"
+    "target": "ES2020"
   },
   "exclude": ["examples/*", "tests/**/*"]
 }


### PR DESCRIPTION
if `additionalProperties` is not of a primitive type, the generated file will contain things like `ref` or `array` instead of interpolating that ref or array.  this PR should fix that and #265.

not aware of any side effects, let me know if you can think of any.