### PR TITLE
bubble up the error message / improve error message when failing to parse the schema

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -43,6 +43,7 @@ const timeStart = process.hrtime();
     spec = await loadSpec(pathToSpec);
   } catch (e) {
     console.error(chalk.red(`❌ "${e}"`));
+    return;
   }
 
   const result = swaggerToTS(spec, {

--- a/bin/loaders/index.js
+++ b/bin/loaders/index.js
@@ -26,10 +26,14 @@ module.exports.loadSpec = async (pathToSpec) => {
     if (isYamlSpec(rawSpec, pathToSpec)) {
       return yaml.safeLoad(rawSpec);
     }
-  } catch {
-    throw new Error(
-      `The spec under ${pathToSpec} seems to be YAML, but it couldn’t be parsed.`
-    );
+  } catch (err) {
+    let message = `The spec under ${pathToSpec} seems to be YAML, but it couldn’t be parsed.`;
+
+    if (err.message) {
+      message += `\n${err.message}`;
+    }
+
+    throw new Error(message);
   }
 
   try {


### PR DESCRIPTION
Two small things:

1) If you fail to load the spec, then return early. Otherwise the `swaggerToTS` function will attempt to execute and obviously fail, giving you a misleading error message

2) Bubble up the error message returned from `yaml.safeLoad()` to give you an idea of why the script is failing

Before:
![Screenshot_20200608_104708](https://user-images.githubusercontent.com/1751182/84044446-9720d300-a975-11ea-960d-fd2aaaeb7f13.png)


After:
![Screenshot_20200608_104615](https://user-images.githubusercontent.com/1751182/84044467-9e47e100-a975-11ea-802b-846fb93a7d52.png)
