### PR TITLE
Add support for http ports

### DIFF
--- a/bin/loaders/loadFromHttp.js
+++ b/bin/loaders/loadFromHttp.js
@@ -12,8 +12,9 @@ function buildOptions(pathToSpec) {
   const requestUrl = url.parse(pathToSpec);
   return {
     method: "GET",
-    hostname: requestUrl.host,
+    hostname: requestUrl.hostname,
     path: requestUrl.path,
+    port: requestUrl.port,
   };
 }
 


### PR DESCRIPTION
Add support for ports. I have a case: run swagger on localhost:5000. And now I have an error:

```
❌ "Error: getaddrinfo ENOTFOUND localhost:5000"
Error: � version missing from schema; specify whether this is OpenAPI v3 or v2 https://swagger.io/specification
    at swaggerVersion (C:\Users\isosnin\AppData\Roaming\npm-cache\_npx\38628\node_modules\@manifoldco\swagger-to-ts\dist-node\index.js:126:9)
    at swaggerToTS (C:\Users\isosnin\AppData\Roaming\npm-cache\_npx\38628\node_modules\@manifoldco\swagger-to-ts\dist-node\index.js:352:19)
    at C:\Users\isosnin\AppData\Roaming\npm-cache\_npx\38628\node_modules\@manifoldco\swagger-to-ts\bin\cli.js:48:18
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

This PR fixes issue.