### PR TITLE
Add support for non-standard ports

### DIFF
--- a/bin/loaders/loadFromHttp.js
+++ b/bin/loaders/loadFromHttp.js
@@ -12,8 +12,9 @@ function buildOptions(pathToSpec) {
   const requestUrl = url.parse(pathToSpec);
   return {
     method: "GET",
-    hostname: requestUrl.host,
+    hostname: requestUrl.hostname,
     path: requestUrl.path,
+    port: requestUrl.port,
   };
 }
 


### PR DESCRIPTION
This makes it possible to connect to i.e. localhost:8080 to generate the types.

Fixes #267 